### PR TITLE
fix: forzar exec_mode fork en pm2 para bot-meta

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -6,6 +6,7 @@ module.exports = {
       interpreter: 'node',
       node_args: '-r tsx/cjs --max-old-space-size=4096',
       instances: 1,
+      exec_mode: 'fork',
       autorestart: true,
       watch: false,
       max_restarts: 10,


### PR DESCRIPTION
instances:1 sin exec_mode explícito hacía que pm2 arrancara el proceso en cluster_mode, lo que lo dejaba en bucle de reinicios (39 restarts, "waiting restart"). El bot es un proceso con estado en memoria (sesiones, colas) y de un único puerto, así que debe correr en fork mode, nunca en cluster con más de una instancia.